### PR TITLE
DM-13534: Use CMake build to ensure everything is installed.

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,17 +1,18 @@
 # EupsPkg config file. Sourced by 'eupspkg'
 
+config()
+{
+    (rm -rf build && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..)
+}
+
+build()
+{
+    (cd build && make)
+}
+
 install()
 {
-	#
-	# Pybind11 uses cmake, but fortunately the scripts are easy
-	# enough to emulate w/o having to have cmake as a dependency
-	#
-
-	clean_old_install
-
-	echo "installing into $PREFIX"
-	mkdir -p "$PREFIX/include"
-	cp -r include/pybind11 "$PREFIX/include"
-
-	install_ups
+    clean_old_install
+    (cd build && make install)
+    install_ups
 }

--- a/ups/pybind11.table
+++ b/ups/pybind11.table
@@ -1,0 +1,1 @@
+envPrepend(CMAKE_PREFIX_PATH, ${PRODUCT_DIR})


### PR DESCRIPTION
In particular, ndarray now uses pybind11's cmake files to find pybind11.