### PR TITLE
DM-15478: If a python error is already set restore it and return

### DIFF
--- a/patches/0001-catch-errors.patch
+++ b/patches/0001-catch-errors.patch
@@ -1,0 +1,13 @@
+--- pybind11/include/pybind11/detail/common.h.orig	2018-08-20 13:33:28.000000000 -0700
++++ pybind11/include/pybind11/detail/common.h	2018-08-20 13:36:06.000000000 -0700
+@@ -287,9 +287,9 @@
+             PYBIND11_CONCAT(pybind11_init_, name)(m);                          \
+             return m.ptr();                                                    \
+         } catch (pybind11::error_already_set &e) {                             \
++            e.restore();                                                       \
+-            PyErr_SetString(PyExc_ImportError, e.what());                      \
+             return nullptr;                                                    \
+         } catch (const std::exception &e) {                                    \
+             PyErr_SetString(PyExc_ImportError, e.what());                      \
+             return nullptr;                                                    \
+         }                                                                      \


### PR DESCRIPTION
Without this python gets confused about the current exception
and the process aborts. Restore the exception that python
already set and do not try to create a new exception.