### PR TITLE
DM-15464: Explicitly say we want python from path

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,7 +2,7 @@
 
 config()
 {
-    (rm -rf build && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..)
+    (rm -rf build && mkdir build && cd build && cmake -DPYTHON_EXECUTABLE:FILEPATH=$(command -v python) -DCMAKE_INSTALL_PREFIX=$PREFIX ..)
 }
 
 build()


### PR DESCRIPTION
I sometimes see pybind11 pick up /usr/local/bin/python even though the anaconda python is ahead of the path. This change to the eupspkg file forces it to use "python" from PATH. This might be related to cmake trying to find the newest python (3.7 is in /usr/local/bin but conda is 3.6).